### PR TITLE
fix(style) : Add space between user avatar and user name in header

### DIFF
--- a/app/styles/global.css
+++ b/app/styles/global.css
@@ -29,6 +29,7 @@ body {
 
 .header-user__name {
   flex: 1 0 auto;
+  margin-inline-start: 0.5em;
 }
 
 .avatar {


### PR DESCRIPTION
Hey, this is just a small visual fix in header :octocat:.

Cya,

Before :
![image](https://github.com/jtanguy/foursfeir/assets/9846217/cb1592fa-a972-4bb8-913e-915c9905693e)
After :
![image](https://github.com/jtanguy/foursfeir/assets/9846217/a1d305eb-cbc9-4499-b9ce-c74edf511acf)
